### PR TITLE
Fix user text color

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,7 +644,7 @@ function renderMessages() {
         messageWrapper.className = `flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`;
         const messageBubble = document.createElement('div');
         messageBubble.className = `max-w-3/4 sm:max-w-md lg:max-w-lg px-3 py-2 sm:px-4 sm:py-2.5 rounded-2xl shadow ${
-            msg.sender === 'user' ? 'user-bubble text-white rounded-br-none' : 'ai-bubble text-slate-800 rounded-bl-none'
+            msg.sender === 'user' ? 'user-bubble text-slate-800 rounded-br-none' : 'ai-bubble text-slate-800 rounded-bl-none'
         }`;
         messageBubble.innerHTML = simpleMarkdownToHtml(msg.text);
         messageWrapper.appendChild(messageBubble);


### PR DESCRIPTION
## Summary
- adjust the user message bubble to use dark text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b884071c832b805298f34ee3c39f