### PR TITLE
Fix help modal closure on click

### DIFF
--- a/index.html
+++ b/index.html
@@ -1284,7 +1284,10 @@ function attachEventListeners() {
     }
     if (elements.helpButton) {
         console.log("도움말 버튼에 이벤트 리스너 연결");
-        elements.helpButton.addEventListener('click', showGuideModal);
+        elements.helpButton.addEventListener('click', (event) => {
+            event.stopPropagation();
+            showGuideModal();
+        });
     }
 
     if (elements.closeGuideModalButton) elements.closeGuideModalButton.addEventListener('click', closeGuideModal);


### PR DESCRIPTION
## Summary
- stop propagation when clicking the help button to prevent the document click handler from immediately closing the guide modal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbe536f8832b82be6550cb3a0e96