### PR TITLE
Add sentence favorite button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This is a simple web app that helps users practice English conversation.
 The main page is `index.html` which loads language files from the `lang` folder
 and uses a small custom stylesheet `style.css` for UI tweaks and animations.
 
-Open `index.html` in a browser to try it out.
+Open `index.html` in a browser to try it out. You can click the star next to any message during a conversation to save it as a favorite.

--- a/index.html
+++ b/index.html
@@ -682,7 +682,9 @@ function exportConversationToJson(returnString = false) {
 }
 
 function applyConversationData(data) {
-    if (Array.isArray(data.messages)) appState.currentMessages = data.messages;
+    if (Array.isArray(data.messages)) {
+        appState.currentMessages = data.messages.map(m => ({ favorite: false, ...m }));
+    }
     if (data.scenarioId) {
         const scenario = findScenarioById(data.scenarioId);
         if (scenario) appState.currentScenario = scenario;
@@ -738,6 +740,16 @@ function renderMessages() {
         }`;
         messageBubble.innerHTML = simpleMarkdownToHtml(msg.text);
         messageWrapper.appendChild(messageBubble);
+        const favButton = document.createElement('button');
+        favButton.className = 'favorite-btn ml-1';
+        favButton.textContent = msg.favorite ? '★' : '☆';
+        favButton.title = appState.UI_TEXT?.favoriteButtonTitle || 'Favorite';
+        favButton.onclick = () => {
+            msg.favorite = !msg.favorite;
+            renderMessages();
+            saveConversationToLocal();
+        };
+        messageWrapper.appendChild(favButton);
         elements.messagesContainer.appendChild(messageWrapper);
     });
     elements.messagesContainer.scrollTop = elements.messagesContainer.scrollHeight;
@@ -1130,7 +1142,7 @@ async function handleSendMessage() {
         return;
     }
 
-    const newUserMessage = { sender: 'user', text: elements.userInputElem.value.trim(), timestamp: new Date() };
+    const newUserMessage = { sender: 'user', text: elements.userInputElem.value.trim(), timestamp: new Date(), favorite: false };
     appState.currentMessages.push(newUserMessage);
     renderMessages();
     saveConversationToLocal();
@@ -1160,12 +1172,12 @@ async function handleSendMessage() {
 
     try {
         const aiResponseText = await callGeminiAPI(promptForAI);
-        const newAiMessage = { sender: 'ai', text: aiResponseText, timestamp: new Date() };
+        const newAiMessage = { sender: 'ai', text: aiResponseText, timestamp: new Date(), favorite: false };
         appState.currentMessages.push(newAiMessage);
         renderMessages();
         saveConversationToLocal();
     } catch (error) {
-        appState.currentMessages.push({ sender: 'ai', text: `${appState.UI_TEXT.aiResponseError} ${error.message}`, timestamp: new Date() });
+        appState.currentMessages.push({ sender: 'ai', text: `${appState.UI_TEXT.aiResponseError} ${error.message}`, timestamp: new Date(), favorite: false });
         renderMessages();
         saveConversationToLocal();
     } finally {

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -29,6 +29,7 @@ export const UI_TEXT = {
     guideModalConfirmButton: "分かりました！",
     appTitle: "SpeakUp AI",
     roleSwapButtonText: "役割変更",
+    favoriteButtonTitle: "お気に入り",
 
     // 가이드 모달 상세 텍스트 (HTML 포함) - 이 부분을 반드시 HTML 파일의 p 태그 내용에 맞게 수정해야 합니다.
     guideP1_html: `<strong>1. 🤖 シナリオ選択:</strong><br/> 画面左上隅の現在のシナリオボタン（例：カフェで）をクリックします。さまざまなカテゴリ別の会話状況を選択したり、「✨ ユーザー設定」を通じてご希望のテーマを直接入力して練習できます。`,

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -28,6 +28,7 @@ export const UI_TEXT = {
     guideModalConfirmButton: "알겠습니다!",
     appTitle: "SpeakUp AI",
     roleSwapButtonText: "역할 변경",
+    favoriteButtonTitle: "즐겨찾기",
 
     // 가이드 모달 상세 텍스트 (HTML 포함) - 이 부분을 반드시 HTML 파일의 p 태그 내용에 맞게 수정해야 합니다.
     guideP1_html: `<strong>1. 🤖 시나리오 선택:</strong><br/> 화면 좌측 상단의 현재 시나리오 버튼 (예: <span class="font-semibold text-sky-600">카페에서</span>)을 클릭하세요. 다양한 카테고리별 대화 상황을 선택하거나, '✨ 사용자 설정'을 통해 직접 원하는 주제를 입력하여 연습할 수 있습니다.`,

--- a/style.css
+++ b/style.css
@@ -76,3 +76,9 @@
     font-size: 0.875rem;
 }
 
+.favorite-btn {
+    color: #fbbf24;
+    font-size: 1.25rem;
+    line-height: 1;
+}
+


### PR DESCRIPTION
## Summary
- allow saving conversation lines as favorites
- display a star next to each message bubble
- keep favorite status when importing/exporting conversations
- update localized UI text in Korean and Japanese
- document the feature in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c61dc868832ba02cea5cea68e2cb