### PR TITLE
Fix favorites persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -690,7 +690,10 @@ function exportConversationToJson(returnString = false) {
 
 function applyConversationData(data) {
     if (Array.isArray(data.messages)) {
-        appState.currentMessages = data.messages.map(m => ({ favorite: false, ...m }));
+        appState.currentMessages = data.messages.map(m => ({
+            ...m,
+            favorite: m.favorite === true
+        }));
     }
     if (data.scenarioId) {
         const scenario = findScenarioById(data.scenarioId);


### PR DESCRIPTION
## Summary
- preserve `favorite` status when loading a saved conversation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cda858e0832bb09d710543b9fce4