### PR TITLE
Make API endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@ The main page is `index.html` which loads language files from the `lang` folder
 and uses a small custom stylesheet `style.css` for UI tweaks and animations.
 
 Open `index.html` in a browser to try it out. Click the star next to any message during a conversation to save it as a favorite. Click the star again to remove it. Use the star button in the header to see all of your saved lines in one place.
+
+## Configuration
+
+The app sends prompts to an external API. The endpoint URL can be customised by
+editing `config.js` at the project root. The file exposes a global
+`APP_CONFIG` object:
+
+```javascript
+window.APP_CONFIG = {
+  API_ENDPOINT: 'https://your-server.example.com/generate'
+};
+```
+
+If you run the app in a Node environment (e.g. during tests), you may instead
+set the `API_ENDPOINT` environment variable.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+window.APP_CONFIG = window.APP_CONFIG || {};
+window.APP_CONFIG.API_ENDPOINT =
+  window.APP_CONFIG.API_ENDPOINT ||
+  (typeof process !== 'undefined' && process.env && process.env.API_ENDPOINT) ||
+  'https://magenta-morning-find.glitch.me/generate';

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         }
     </style>
+    <script src="./config.js"></script>
 </head>
 <body class="flex flex-col items-center justify-center min-h-screen gradient-bg p-2 sm:p-4">
 
@@ -518,7 +519,10 @@ const langPacks = {
 
 // --- 앱 설정 ---
 const APP_ID = 'ai-tutor-html-default-v1';
-const API_ENDPOINT = "https://magenta-morning-find.glitch.me/generate";
+const API_ENDPOINT =
+    (window.APP_CONFIG && window.APP_CONFIG.API_ENDPOINT) ||
+    (typeof process !== 'undefined' && process.env && process.env.API_ENDPOINT) ||
+    "https://magenta-morning-find.glitch.me/generate";
 
 // --- 앱의 전역 상태 관리 ---
 const appState = {


### PR DESCRIPTION
## Summary
- allow configuring API endpoint via `config.js` or environment variable
- document configuration in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840dd693f40832b8915616d9186a4b3