### PR TITLE
🔒 Fix Plaintext Storage of API Key in LocalStorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2610,13 +2610,6 @@ export default function App() {
               <option value="push">직설적으로</option>
             </select>
           </label>
-
-          <ToggleField
-            label="API 키 로컬 저장"
-            description="끄면 새로고침 후 로컬 저장소에서 API 키를 지웁니다."
-            checked={settings.saveApiKey}
-            onChange={(checked) => setSettings((current) => ({ ...current, saveApiKey: checked }))}
-          />
         </section>
 
         <section className="settings-section">

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -18,7 +18,6 @@ const STORAGE_KEYS = {
 export const defaultSettings: Settings = {
   apiKey: '',
   model: 'gemini-3-flash-preview',
-  saveApiKey: false,
   themeMode: 'light',
   userName: '',
   coachMode: 'balanced',
@@ -50,7 +49,7 @@ export function loadSettings(): Settings {
         ? settings.model
         : defaultSettings.model,
     voiceName: isGeminiTtsVoice(settings.voiceName) ? settings.voiceName : defaultSettings.voiceName,
-    apiKey: settings.saveApiKey ? settings.apiKey ?? '' : '',
+    apiKey: '', // API Key is never loaded from localStorage for security reasons
   };
 }
 
@@ -59,9 +58,7 @@ export function saveSettings(settings: Settings): void {
     ...settings,
     model: defaultSettings.model,
   };
-  const next = sanitized.saveApiKey
-    ? sanitized
-    : { ...sanitized, apiKey: '' };
+  const next = { ...sanitized, apiKey: '' }; // API Key is never saved to localStorage for security reasons
   window.localStorage.setItem(STORAGE_KEYS.settings, JSON.stringify(next));
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,6 @@ export interface SuggestionBundle {
 export interface Settings {
   apiKey: string;
   model: string;
-  saveApiKey: boolean;
   themeMode: ThemeMode;
   userName: string;
   coachMode: CoachMode;


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The application previously allowed users to save their Gemini API key in the browser's `localStorage`. This resulted in the sensitive API key being stored in plaintext, exposing it to potential theft via Cross-Site Scripting (XSS) attacks or unauthorized physical access to the browser profile.

⚠️ **Risk:** The potential impact if left unfixed
If an attacker manages to execute malicious JavaScript on the page (XSS), or gains access to the local machine, they can easily read the `localStorage` and extract the plaintext API key. This key could then be abused to consume the user's API quota or access AI models on their behalf.

🛡️ **Solution:** How the fix addresses the vulnerability
This fix entirely removes the option to save the API key locally. The `saveApiKey` toggle has been removed from the UI and the `Settings` type. The storage logic (`src/lib/storage.ts`) has been updated to strictly ensure that the `apiKey` property is cleared before writing to `localStorage`, and is always initialized as an empty string when loading settings. The API key must now be provided per-session and is kept strictly in memory.

---
*PR created automatically by Jules for task [977768085536329993](https://jules.google.com/task/977768085536329993) started by @alibowbow*